### PR TITLE
NEW - Add toasts

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,6 +13,7 @@
         "pinia": "^3.0.3",
         "vue": "^3.5.21",
         "vue-router": "^4.5.1",
+        "vue-toastification": "^2.0.0-rc.5",
         "vuetify": "^3.10.1"
       },
       "devDependencies": {
@@ -6750,6 +6751,15 @@
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
       "license": "MIT"
+    },
+    "node_modules/vue-toastification": {
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/vue-toastification/-/vue-toastification-2.0.0-rc.5.tgz",
+      "integrity": "sha512-q73e5jy6gucEO/U+P48hqX+/qyXDozAGmaGgLFm5tXX4wJBcVsnGp4e/iJqlm9xzHETYOilUuwOUje2Qg1JdwA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": "^3.0.2"
+      }
     },
     "node_modules/vuetify": {
       "version": "3.10.6",

--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "pinia": "^3.0.3",
     "vue": "^3.5.21",
     "vue-router": "^4.5.1",
+    "vue-toastification": "^2.0.0-rc.5",
     "vuetify": "^3.10.1"
   },
   "devDependencies": {

--- a/client/src/components/Login.vue
+++ b/client/src/components/Login.vue
@@ -70,6 +70,9 @@
   import { ref } from 'vue'
   import FetchService from "../FetchService.js"
   import { useAppStore } from '@/stores/app.js';
+  import { useToast } from 'vue-toastification'
+
+  const toast = useToast()
 
 
   const username = ref();
@@ -102,6 +105,7 @@
       store.loggedIn = true;
     } catch (error) {
       console.error("Login failed:", error);
+      toast.error("Incorrect username or password");
       errorMessages.value.password = "incorrect username or password"
       isIncorrect.value = true;
     }

--- a/client/src/pages/Chore.vue
+++ b/client/src/pages/Chore.vue
@@ -229,8 +229,10 @@
   import { useAppStore } from "../stores/app.js";
   import { useRouter, useRoute } from 'vue-router';
   import FetchService from '../FetchService.js'
+  import { useToast } from 'vue-toastification'
 
   const store = useAppStore();
+  const toast = useToast()
   const props = defineProps({
     viewMode: String,
     choreId: Number,
@@ -244,7 +246,8 @@
       name: 'viewChore',
       params: { id: props.choreId }
     })
-    //TODO: add a toaster to indicate why it rerouted
+    
+    toast.error("You cannot edit a chore if you are not a leader")
   }
 
   const members = store.household.users
@@ -283,7 +286,7 @@
           name: 'viewChore',
           params: { id: props.choreId }
         })
-        //TODO: add a toaster to indicate why it rerouted
+        toast.error("You cannot edit a chore if you are not a leader")
       }
 
       let viewMode;
@@ -318,7 +321,7 @@
         const choreDate = new Date(chore.value.dueDate);
         chore.value.dueDate = choreDate.toLocaleDateString('en-CA');
       } else {
-        //TODO: add a toast to indicate that the chore was not found
+        toast.error("That chore was not found in your household")
         console.log("no chore with " + choreId + " id is in the household")
         return {};
       }
@@ -326,7 +329,7 @@
 
     if(chore.value.householdId != store.user.householdId) {
       router.push({ name: 'home' });
-      //TODO: add a toaster to indicate why it rerouted
+      toast.error("That chore was not found in your household")
     }
 
     //Create the values needed to display description and assignee in view mode
@@ -400,8 +403,6 @@
         errorMessages.value.dueDate = ''
       }
     }
-
-    //TODO: send a toast if it is not valid
     
     return valid;
   }
@@ -421,8 +422,14 @@
       }
 
       const result = await FetchService.createChore(choreForDatabase);
-      //TODO: add a toast if the create failed
-      store.household.chores.push(result);
+
+      if(result) {
+        store.household.chores.push(result);
+
+        toast.success("Chore created successfully")
+      } else {
+        toast.error("Something went wrong. The chore was unable to be created.")
+      }
 
       router.push({ name: 'home'});
       return result;
@@ -447,16 +454,21 @@
 
       const result = await FetchService.editChore(props.choreId, choreForDatabase);
 
-      //TODO: add a toast if the update failed
+      if(result) {
+        toast.success("Chore updated successfully")
 
-      var choreIndex = -1;
-      for(var index = 0; index < store.household.chores.length; index++) {
-        if(store.household.chores[index].id == props.choreId) {
-          choreIndex = index
+        var choreIndex = -1;
+        for(var index = 0; index < store.household.chores.length; index++) {
+          if(store.household.chores[index].id == props.choreId) {
+            choreIndex = index
+          }
         }
+
+        store.household.chores[choreIndex] = choreForDatabase;
+      } else {
+        toast.error("Something went wrong. The chore was unable to be updated.")
       }
 
-      store.household.chores[choreIndex] = choreForDatabase;
       router.push({ name: 'viewChore', params: {id: props.choreId}});
       return result;
     }

--- a/client/src/pages/Dashboard.vue
+++ b/client/src/pages/Dashboard.vue
@@ -392,9 +392,10 @@
   import { useRouter } from 'vue-router'
   import FetchService from '../FetchService.js'
   import Avatar from '../components/Avatar.vue'
+  import { useToast } from 'vue-toastification'
 
   const store = useAppStore()
-
+  const toast = useToast()
   const router = useRouter()
 
   const listMode = ref(true);
@@ -444,11 +445,14 @@
     const result = await FetchService.deleteChore(choreId)
     deleteDialogOpen.value = false
     deleteDialogChore.value = null
-    choreList.value = choreList.value.filter(chore => chore.id != choreId)
-    unassignedList.value = unassignedList.value.filter(chore => chore.id != choreId)
-    store.household.chores = store.household.chores.filter(chore => chore.id != choreId)
-
-    //TODO: add toaster that confirms it was deleted
+    if(result) {
+      toast.success("The chore was successfully deleted")
+      choreList.value = choreList.value.filter(chore => chore.id != choreId)
+      unassignedList.value = unassignedList.value.filter(chore => chore.id != choreId)
+      store.household.chores = store.household.chores.filter(chore => chore.id != choreId)
+    } else {
+      toast.error("Something went wrong. That chore was unable to be deleted")
+    }
   }
 
   function assignToSelfPrompt(chore) {
@@ -474,11 +478,14 @@
     assignDialogOpen.value = false;
     assignDialogChore.value = null;
 
-    choreList.value.push(choreForDatabase)
-    unassignedList.value = unassignedList.value.filter(listChore => listChore.id != chore.id);
-    store.household.chores.filter(listChore => listChore.id == chore.id).forEach(listChore => listChore.assigneeId = store.user.id)
-
-    //TODO: add toaster to confirm the chore was able to be assigned
+    if(result) {
+      toast.success("The chore was able to be successfully assigned")
+      choreList.value.push(choreForDatabase)
+      unassignedList.value = unassignedList.value.filter(listChore => listChore.id != chore.id);
+      store.household.chores.filter(listChore => listChore.id == chore.id).forEach(listChore => listChore.assigneeId = store.user.id)
+    } else {
+      toast.error("Something went wrong. That chore was unable to be assigned to you")
+    }
   }
 
   function completeChorePrompt(chore) {
@@ -505,19 +512,23 @@
   async function completeChore(chore) {
     const result = await FetchService.deleteChore(chore.id)
 
-    completeDialogOpen.value = false
-    completeDialogChore.value = null
-    choreList.value = choreList.value.filter(listChore => listChore.id != chore.id)
-    store.household.chores = store.household.chores.filter(listChore => listChore.id != chore.id)
+    if(result) {
 
-    const userResult = await FetchService.updateUserPoints(store.user.id, chorePoints(chore))
+      completeDialogOpen.value = false
+      completeDialogChore.value = null
+      choreList.value = choreList.value.filter(listChore => listChore.id != chore.id)
+      store.household.chores = store.household.chores.filter(listChore => listChore.id != chore.id)
 
-    store.user = userResult;
+      const userResult = await FetchService.updateUserPoints(store.user.id, chorePoints(chore))
 
-    const householdUser = store.household.users.find((user) => user.id == store.user.id)
-    householdUser.totalPoints = userResult.totalPoints
+      store.user = userResult;
 
-    //TODO: add a toaster to confirm that the chore was completed.
+      toast.success("The chore was completed successfully")
+      const householdUser = store.household.users.find((user) => user.id == store.user.id)
+      householdUser.totalPoints = userResult.totalPoints
+    } else {
+      toast.error("Something went wrong. The chore was unable to be completed")
+    }
   }
 
   function filterChores() {

--- a/client/src/pages/Household.vue
+++ b/client/src/pages/Household.vue
@@ -316,10 +316,10 @@
   import { useAppStore } from '@/stores/app';
   import { useRouter } from 'vue-router'
   import FetchService from '../FetchService.js'
+  import { useToast } from 'vue-toastification'
 
   const store = useAppStore()
-
-  const listMode = ref(true);
+  const toast = useToast()
   const errorMessages = ref({household: ""})
   const joinCode = ref()
   const showLastToLeaveDialog = ref(false)
@@ -360,20 +360,26 @@
     let lastHouseId = store.household.id
     if(!house){
       errorMessages.value.household = "Join code does not exist" 
+      toast.error("That join code does not exist")
     } else {
       store.household.id = house.id
       store.household.name = house.name
       store.household.joinCode = house.joinCode
       const result = await FetchService.leaveHousehold(store.user.id, house.id);
-      householdName.value = ""
-      store.household = await FetchService.fetchHousehold(house.id);
-      members.value = store.household.users.filter(user => user.role == 'member')
-      leaders.value = store.household.users.filter(user => user.role == 'leader')
-      showDialog.value = false
-      errorMessages.value.household= ""
-      if (lastFlag.value){
-        await FetchService.deleteHousehold(lastHouseId)
-        lastFlag.value = false
+      if(result) {
+        toast.success("You were able to join the household successfully.")
+        householdName.value = ""
+        store.household = await FetchService.fetchHousehold(house.id);
+        members.value = store.household.users.filter(user => user.role == 'member')
+        leaders.value = store.household.users.filter(user => user.role == 'leader')
+        showDialog.value = false
+        errorMessages.value.household= ""
+        if (lastFlag.value){
+          await FetchService.deleteHousehold(lastHouseId)
+          lastFlag.value = false
+        }
+      } else {
+        toast.error("Something went wrong. You were not able to leave your household.")
       }
     }
     methodComplete.value = true;
@@ -405,16 +411,21 @@
     store.household.joinCode = house.joinCode
     joinCode.value = house.joinCode
     const result = await FetchService.leaveHousehold(store.user.id, house.id);
-    householdName.value = ""
-    store.household = await FetchService.fetchHousehold(house.id);
+    if(result) {
+      toast.success("You successfully created a new household.")
+      householdName.value = ""
+      store.household = await FetchService.fetchHousehold(house.id);
 
-    members.value = store.household.users.filter((user) => user.role == 'member')
-    leaders.value = store.household.users.filter((user) => user.role == 'leader')
-    showDialog.value = false
-    errorMessages.value.household = ""
-    if (lastFlag.value){
-      await FetchService.deleteHousehold(lastHouseId)
-      lastFlag.value = false
+      members.value = store.household.users.filter((user) => user.role == 'member')
+      leaders.value = store.household.users.filter((user) => user.role == 'leader')
+      showDialog.value = false
+      errorMessages.value.household = ""
+      if (lastFlag.value){
+        await FetchService.deleteHousehold(lastHouseId)
+        lastFlag.value = false
+      }
+    } else {
+      toast.error("Something went wrong. You were unable to leave your household")
     }
     methodComplete.value = true;
   }

--- a/client/src/pages/Profile.vue
+++ b/client/src/pages/Profile.vue
@@ -56,7 +56,10 @@ import { ref } from 'vue';
 import { useAppStore } from "../stores/app.js";
 import FetchService from '@/FetchService';
 import Avatar from '../components/Avatar.vue'
+import { useToast } from 'vue-toastification'
+
 const store = useAppStore();
+const toast = useToast();
 const username = ref(store.user.email);
 const isUpdate = ref(false)
 const password = ref();
@@ -104,10 +107,15 @@ async function updateProfile() {
       confirmed.value = false
       password.value = ""
       repeatedPassword.value = ""
-      store.user.name = name.value
-      store.user.email = username.value
-      store.user.difficulty = maxDifficulty.value
-      store.user.maxChoreTime = estimatedTime.value
+      if(result) {
+        toast.success("Your profile was updated successfully")
+        store.user.name = name.value
+        store.user.email = username.value
+        store.user.difficulty = maxDifficulty.value
+        store.user.maxChoreTime = estimatedTime.value
+      } else {
+        toast.error("Something went wrong. Your profile was unable to be updated")
+      }
       isUpdate.value = false;
       errorMessages.value.previousPassword = ""
       return true;
@@ -123,6 +131,12 @@ async function updateProfile() {
       difficulty: maxDifficulty.value,
       maxChoreTime: estimatedTime.value
     })
+
+    if(result) {
+      toast.success("Profile updated sucessfully")
+    } else {
+      toast.error("Something went wrong. Your profile was unable to be updated")
+    }
   }
 
   store.user.name = name.value
@@ -137,7 +151,13 @@ async function updateProfile() {
 function deleteProfile(id) {
   const result = FetchService.deleteUser(id)
   showDialog.value = false
-  store.loggedIn = false
+  if(result) {
+    store.loggedIn = false
+    toast.success("Your profile was deleted successfully")
+  } else {
+    toast.error("Something went wrong. Your profile was unable to be deleted")
+  }
+  
   return result;
 }
 

--- a/client/src/pages/Random.vue
+++ b/client/src/pages/Random.vue
@@ -108,8 +108,10 @@
   import { useAppStore } from "../stores/app.js";
   import { useRouter, useRoute } from 'vue-router';
   import FetchService from '../FetchService.js'
+  import { useToast } from 'vue-toastification'
 
   const store = useAppStore();
+  const toast = useToast();
   const router = useRouter();
 
   const assignedChores = ref([])
@@ -120,7 +122,7 @@
     router.push({
       name: 'home'
     })
-    //TODO: add a toaster to indicate why it rerouted
+    toast.error("Only a leader is able to randomly assign chores")
   }
 
   onMounted(async () => {

--- a/client/src/pages/Store.vue
+++ b/client/src/pages/Store.vue
@@ -77,8 +77,10 @@
   import { onMounted, ref } from 'vue'
   import { useAppStore } from '@/stores/app'
   import FetchService from '../FetchService.js'
+  import { useToast } from 'vue-toastification'
 
   const store = useAppStore()
+  const toast = useToast()
 
   const ownedProps = ref([])
   const propsList = ref([])
@@ -169,9 +171,13 @@
     if(store.user.currentPoints >= prop.cost) {
       let result = await FetchService.buyProp(store.user.id, prop.id)
 
-      ownedProps.value.push(prop.id)
-      store.user.currentPoints = result.currentPoints
-
+      if(result) {
+        ownedProps.value.push(prop.id)
+        store.user.currentPoints = result.currentPoints
+        toast.success("The prop was bought successfully")
+      } else {
+        toast.error("Something went wrong. The prop was unable to be bought")
+      }
       return true;
     } else {
       tooExpensiveDialogOpen.value = true;
@@ -182,15 +188,19 @@
   async function equipProp(prop) {
     let result = await FetchService.equipProp(store.user.id, prop)
 
-    usersAvatar.value[prop.type] = {
-      url: prop.url,
-      id: prop.id
-    };
-    store.avatars.find((avatar) => avatar.userId == store.user.id)[prop.type] = {
-      url: prop.url,
-      id: prop.id,
+    if(result) {
+      toast.success("The prop was successfully equipped")
+      usersAvatar.value[prop.type] = {
+        url: prop.url,
+        id: prop.id
+      };
+      store.avatars.find((avatar) => avatar.userId == store.user.id)[prop.type] = {
+        url: prop.url,
+        id: prop.id,
+      }
+    } else {
+      toast.error("Something went wrong. The prop was not successfully equipped")
     }
-
     return true;
   }
 

--- a/client/src/plugins/index.js
+++ b/client/src/plugins/index.js
@@ -1,17 +1,13 @@
-/**
- * plugins/index.js
- *
- * Automatically included in `./src/main.js`
- */
-
 // Plugins
 import vuetify from './vuetify'
 import pinia from '@/stores'
 import router from '../router/router'
+import { toast, toastOptions } from './toast.js'
 
 export function registerPlugins (app) {
   app
     .use(vuetify)
     .use(router)
     .use(pinia)
+    .use(toast, toastOptions)
 }

--- a/client/src/plugins/toast.js
+++ b/client/src/plugins/toast.js
@@ -1,0 +1,22 @@
+import Toast from 'vue-toastification'
+import "vue-toastification/dist/index.css"
+
+export const toastOptions = {
+    transition: "Vue-Toastification__bounce",
+    maxToasts: 10,
+    newestOnTop: true,
+    position: "bottom-right",
+    timeout: 4000,
+    closeOnClick: true,
+    pauseOnFocusLoss: true,
+    pauseOnHover: true,
+    draggable: true,
+    draggablePercent: 0.6,
+    showCloseButtonOnHover: false,
+    hideProgressBar: true,
+    closeButton: "button",
+    icon: true,
+    rtl: false
+};
+
+export const toast = Toast;


### PR DESCRIPTION
This adds toasts for: 
- Unsuccessful login
- Chore creation
- Successful chore edit
- Successful/Unsuccessful chore delete
- Successful/Unsuccessful chore complete
- Successful/Unsuccessful chore assignment to self
- Force re-routes from chore (edit mode if not leader and accessing chore not in household)
- Successful buy prop
- Successful equip prop
- Successful update profile
- Successful delete profile
- Successful leave household
- Reroute for a member off of random page

This does not add any tests because all of the new branches require FetchService to fail. If you want I can force FetchService to fail, but I thought we decided that that was usually unnecessary. 

Closes #32 