### PR TITLE
Added ability to override maximum time

### DIFF
--- a/client/src/pages/Random.vue
+++ b/client/src/pages/Random.vue
@@ -2,7 +2,23 @@
   <v-sheet class="w-100 fill-height" color="navy">
     <div class="text-h4 text-md-h2 ml-3 pt-2 mb-3">Random Assignment</div>
     <v-row class="mr-2 ml-2 mb-3 mt-3">
-      <v-col offset-md="5" cols="12" md="3" class="pt-1 pb-1">
+      <v-col cols="12" md="5">
+        <v-tooltip 
+          text="This allows the random assignment to go beyond a users maximum available time so that more chores can be assigned."
+          location="bottom"
+        >
+          <template v-slot:activator="{ props }">
+            <v-checkbox
+              v-model="overrideMaxTime"
+              label="Override the users' maximum time?"
+              v-bind="props"
+              density="compact"
+              id="overrideMaxTimeCheckbox"
+            ></v-checkbox>
+          </template>
+        </v-tooltip>
+      </v-col>
+      <v-col cols="12" md="3" class="pt-1 pb-1">
         <v-btn
             color="secondary"
             block
@@ -125,6 +141,7 @@
   const assignedChores = ref([])
   const unassignedChores = ref([])
   const mounted = ref(false)
+  const overrideMaxTime = ref(false)
 
   if(store.user.role != 'leader') {
     router.push({
@@ -183,7 +200,7 @@
     }
 
     //identify last index of a user that has the corresponding max difficulty or above
-    let userDifficultyIndex = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    let userDifficultyIndex = [-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1]
     for(let userIndex = 0; userIndex < userTime.length; userIndex++) {
       for(let difficultyIndex = userTime[userIndex].difficulty; difficultyIndex > 0; difficultyIndex--) {
         userDifficultyIndex[difficultyIndex] = userIndex;
@@ -212,6 +229,47 @@
         assignedChores.value.push(originalChores[choreIndex])
       } else {
         unassignedChores.value.push(originalChores[choreIndex])
+      }
+    }
+
+    if(overrideMaxTime.value) {
+      //Only want to sort the chores that would have been unassigned before
+      let randomUnassignedChores = unassignedChores.value
+      unassignedChores.value = []
+
+      for(let choreIndex = 0; choreIndex < randomUnassignedChores.length; choreIndex++) {
+        let choreDifficulty = randomUnassignedChores[choreIndex].difficulty;
+
+        //find users that have time to complete this chore
+        let availableUsers = [];
+        for(let userIndex = 0; userIndex < userDifficultyIndex[choreDifficulty] + 1; userIndex++) {
+          availableUsers.push(userTime[userIndex])
+        }
+
+        //Sort the users by the time they have available
+        availableUsers = availableUsers.sort((user1, user2) => user2.maxChoreTime - user1.maxChoreTime)
+
+        if(availableUsers.length > 0) {
+          //Select a random available user
+          //Weight it so that users with more time available have a higher weight
+          let userWieght = Math.floor(Math.random() * (availableUsers.length * (availableUsers.length + 1) / 2))
+
+          //Find the users index by doing the reverse of how it was weighted
+          let userIndex = Math.floor(Math.sqrt(2 * userWieght + 0.25) - 0.5)
+
+          if(userIndex < 0) {
+            userIndex = 0
+          } else if(userIndex >= availableUsers.length) {
+            userIndex = availableUsers.length - 1
+          }
+          
+          //Update the chore information and the user information for the chore to be assigned
+          randomUnassignedChores[choreIndex].assigneeId = availableUsers[userIndex].id
+          userTime.find((user) => user.id == availableUsers[userIndex].id).maxChoreTime -= randomUnassignedChores[choreIndex].estimatedTime;
+          assignedChores.value.push(randomUnassignedChores[choreIndex])
+        } else {
+          unassignedChores.value.push(randomUnassignedChores[choreIndex])
+        }
       }
     }
   }

--- a/client/src/tests/random.spec.js
+++ b/client/src/tests/random.spec.js
@@ -355,6 +355,144 @@ test("RCAT-1, RCAT-2 and RCAT-4 - randomize lists the chores correctly", async (
     expect(wrapper.vm.unassignedChores.length).toBe(3)
 })
 
+test("OMT-1 - randomize goes past maximum time if user has selected to override", async () => {
+    const wrapper = mount(Random, {
+        global: {
+            plugins: [
+                createTestingPinia({
+                    createSpy: vi.fn,
+                    initialState: {
+                        app: {
+                            user: {
+                                id: 1,
+                                householdId: 1,
+                                role: "leader",
+                            },
+                            household: {
+                                users: [
+                                    {
+                                        id: 4,
+                                        name: "test",
+                                        role: "member",
+                                        difficulty: 5,
+                                        maxChoreTime: 20
+                                    },
+                                    {
+                                        id: 6,
+                                        name: "test2",
+                                        role: "member",
+                                        difficulty: 9,
+                                        maxChoreTime: 5
+                                    },
+                                    {
+                                        id: 8,
+                                        name: "test3",
+                                        role: "member",
+                                        difficulty: 1,
+                                        maxChoreTime: 60
+                                    }
+                                ],
+                                chores: [
+                                    {
+                                        id: 1,
+                                        name: "test name too difficult for anyone",
+                                        difficulty: 10,
+                                        estimatedTime: 20,
+                                        householdId: 1,
+                                        assigneeId: null,
+                                    },
+                                    {
+                                        id: 2,
+                                        name: "test name",
+                                        difficulty: 4,
+                                        estimatedTime: 15,
+                                        householdId: 1,
+                                        assigneeId: null,
+                                    },
+                                    {
+                                        id: 3,
+                                        name: "test name",
+                                        difficulty: 3,
+                                        estimatedTime: 10,
+                                        householdId: 1,
+                                        assigneeId: null,
+                                    },
+                                    {
+                                        id: 4,
+                                        name: "test name multiple",
+                                        difficulty: 1,
+                                        estimatedTime: 20,
+                                        householdId: 1,
+                                        assigneeId: null,
+                                    },
+                                    {
+                                        id: 5,
+                                        name: "test name multiple",
+                                        difficulty: 1,
+                                        estimatedTime: 20,
+                                        householdId: 1,
+                                        assigneeId: null,
+                                    },
+                                    {
+                                        id: 6,
+                                        name: "test name multiple",
+                                        difficulty: 1,
+                                        estimatedTime: 20,
+                                        householdId: 1,
+                                        assigneeId: null,
+                                    },
+                                    {
+                                        id: 7,
+                                        name: "test name",
+                                        difficulty: 1,
+                                        estimatedTime: 15,
+                                        householdId: 1,
+                                        assigneeId: 8,
+                                    }
+                                ]
+                            },
+                        },
+                    },
+                }),
+                [vuetify],
+                routes,
+            ],
+        }
+    })
+
+    wrapper.vm.overrideMaxTime = true
+
+    wrapper.vm.randomize()
+
+    expect(wrapper.vm.assignedChores).toContainEqual({
+        id: 2,
+        name: "test name",
+        difficulty: 4,
+        estimatedTime: 15,
+        assigneeId: 4,
+    })
+    expect(wrapper.vm.unassignedChores).toContainEqual({
+        id: 1,
+        name: "test name too difficult for anyone",
+        difficulty: 10,
+        estimatedTime: 20,
+        assigneeId: null,
+    })
+    expect(wrapper.vm.assignedChores).toContainEqual({
+        id: 3,
+        name: "test name",
+        difficulty: 3,
+        estimatedTime: 10,
+        assigneeId: expect.any(Number),
+    })
+    expect(wrapper.vm.assignedChores.filter((chore) => chore.name == 'test name multiple').length).toBe(3)
+
+    expect(wrapper.vm.unassignedChores.filter((chore) => chore.name == 'test name multiple').length).toBe(0)
+
+    expect(wrapper.vm.assignedChores.length).toBe(5)
+    expect(wrapper.vm.unassignedChores.length).toBe(1)
+})
+
 test("RCAT-1 - assignChores assigns correctly", async () => {
 
     let router = createRouter({
@@ -672,6 +810,71 @@ test("RCAT-1 - test assignButton", async () => {
     await wrapper.find('#assignChoresButton').trigger("click")
 
     expect(spy).toHaveBeenCalled()
+})
+
+test("OMT-1 - test overrideMaxTimeCheckbox", async () => {
+
+    const wrapper = mount(Random, {
+        global: {
+            plugins: [
+                createTestingPinia({
+                    createSpy: vi.fn,
+                    initialState: {
+                        app: {
+                            user: {
+                                id: 4,
+                                householdId: 3,
+                                role: "leader",
+                                name: "test"
+                            },
+                            household: {
+                                users: [
+                                    {
+                                        id: 4,
+                                        name: "test",
+                                        role: "member",
+                                        difficulty: 5,
+                                        maxChoreTime: 20
+                                    }
+                                ],
+                                chores: [
+                                    {
+                                        id: 2,
+                                        name: "test name",
+                                        difficulty: 1,
+                                        estimatedTime: 1,
+                                        householdId: 3,
+                                        assigneeId: null,
+                                    },
+                                    {
+                                        id: 3,
+                                        name: "test name",
+                                        difficulty: 1,
+                                        estimatedTime: 1,
+                                        householdId: 3,
+                                        assigneeId: null,
+                                    },
+                                ]
+                            },
+                        },
+                    },
+                }),
+                [vuetify],
+                routes,
+            ],
+        }
+    })
+
+    //flushPromises wouldn't work for some reason so I need to wait for a state to change at the end of onMounted manually
+    while(!wrapper.vm.mounted) {
+        await new Promise(resolve => setTimeout(resolve, 50))
+    }
+
+    const checkbox = await wrapper.find('#overrideMaxTimeCheckbox')
+
+    checkbox.setValue(true)
+
+    expect(wrapper.vm.overrideMaxTime).toBe(true)
 })
 
 test("NOFT - reroutes correctly when a member tries to access", async () => {


### PR DESCRIPTION
This adds the ability to override a users maximum time curing random chore assignment. It still follows users max difficulty levels, and it weights the random so that users with more leftover time will have a higher chance of getting the chores. 

### Note
Because of the UI changes in small-screen-friendly, this branch was based off of that branch. That branch should be merged into main before this one. If this one is merged first, it will actually merge into small-screen-friendly instead of main and it will just add the changes from this branch to that one.

Closes #99 