### PR TITLE
Removed the gap in the navigation bar

### DIFF
--- a/client/src/components/NavigationBar.vue
+++ b/client/src/components/NavigationBar.vue
@@ -31,10 +31,6 @@
             </v-list-item>
             <v-list-item title = "Print" value = "print" to="/print"></v-list-item>
             <v-list-item title = "Help" value = "help" to="/help"></v-list-item>
-          </v-list>
-        </v-container>
-        <v-container class="primary-lighten-1 text-center pa-0 mt-auto" width="100%">
-          <v-list bg-color="primary" width="100%">
             <v-list-item title = "Leaderboard" value = "leaderboard" to="/leaderboard"></v-list-item>
             <v-list-item title = "Store" value = "store" to="/store"></v-list-item>
           </v-list>


### PR DESCRIPTION
Removed the gap in the navigation bar so that buttons don't go to the bottom of the screen with the help page.

Closes #112 